### PR TITLE
Various fixes from testing against other equipment

### DIFF
--- a/redfish_use_case_checkers/boot_override.py
+++ b/redfish_use_case_checkers/boot_override.py
@@ -227,17 +227,27 @@ def boot_test_boot_check(sut: SystemUnderTest, systems: list):
         # Cache the allowable boot parameters
         # If the allowable values term is not present, assume it supports PXE, Continuous, and Once
         boot_params = {}
-        boot_params["PXE"] = system["Boot"].get("BootSourceOverrideTarget@Redfish.AllowableValues", ["Pxe"])
-        boot_params["USB"] = system["Boot"].get("BootSourceOverrideTarget@Redfish.AllowableValues", [])
-        boot_params["Continuous"] = system["Boot"].get(
-            "BootSourceOverrideEnabled@Redfish.AllowableValues", ["Continuous"]
+        boot_params["PXE"] = (
+            True if "Pxe" in system["Boot"].get("BootSourceOverrideTarget@Redfish.AllowableValues", ["Pxe"]) else False
         )
-        boot_params["Once"] = system["Boot"].get("BootSourceOverrideEnabled@Redfish.AllowableValues", ["Once"])
+        boot_params["USB"] = (
+            True if "USB" in system["Boot"].get("BootSourceOverrideTarget@Redfish.AllowableValues", []) else False
+        )
+        boot_params["Continuous"] = (
+            True
+            if "Continuous" in system["Boot"].get("BootSourceOverrideEnabled@Redfish.AllowableValues", ["Continuous"])
+            else False
+        )
+        boot_params["Once"] = (
+            True
+            if "Once" in system["Boot"].get("BootSourceOverrideEnabled@Redfish.AllowableValues", ["Once"])
+            else False
+        )
         boot_override_params.append(boot_params)
 
         # Check if the boot object contains other properties as needed by the allowable boot override targets
-        boot_override_targets = ["UefiTarget", "UefiHttp", "UefiBootNext"]
-        boot_override_properties = ["UefiTargetBootSourceOverride", "HttpBootUri", "BootNext"]
+        boot_override_targets = ["UefiTarget", "UefiBootNext"]
+        boot_override_properties = ["UefiTargetBootSourceOverride", "BootNext"]
         for target, prop in zip(boot_override_targets, boot_override_properties):
             operation = "Checking that the 'Boot' property in system '{}' contains the '{}' property".format(
                 system["Id"], target
@@ -355,7 +365,6 @@ def boot_test_continuous_boot_settings(sut: SystemUnderTest, systems: list, boot
                     operation,
                     "FAIL",
                     "'Boot' property contains '{}'/'{}' instead of '{}'/'{}' after PATCH operation.".format(
-                        system["Id"],
                         boot_obj["BootSourceOverrideTarget"],
                         boot_obj["BootSourceOverrideEnabled"],
                         boot_path,
@@ -455,7 +464,6 @@ def boot_test_one_time_boot_settings(sut: SystemUnderTest, systems: list, boot_o
                     operation,
                     "FAIL",
                     "'Boot' property contains '{}'/'{}' instead of '{}'/'{}' after PATCH operation.".format(
-                        system["Id"],
                         boot_obj["BootSourceOverrideTarget"],
                         boot_obj["BootSourceOverrideEnabled"],
                         boot_path,
@@ -629,7 +637,6 @@ def boot_test_disable_boot_settings(sut: SystemUnderTest, systems: list, boot_ov
                     operation,
                     "FAIL",
                     "'Boot' property contains '{}'/'{}' instead of '{}'/'{}' after PATCH operation.".format(
-                        system["Id"],
                         boot_obj["BootSourceOverrideTarget"],
                         boot_obj["BootSourceOverrideEnabled"],
                         boot_path,

--- a/redfish_use_case_checkers/power_control.py
+++ b/redfish_use_case_checkers/power_control.py
@@ -190,7 +190,7 @@ def power_test_reset_operation(sut: SystemUnderTest, systems: list, reset_capabi
 
     test_name = TEST_RESET_OPERATION[0]
     logger.log_use_case_test_header(CAT_NAME, test_name)
-    reset_types = ["On", "ForceOn", "ForceOff", "ForceRestart", "PowerCycle"]
+    reset_types = ["ForceOff", "ForceRestart", "PowerCycle", "On", "ForceOn"]
 
     # Test each reset type
     for reset_type in reset_types:


### PR DESCRIPTION
A few minor updates to address some issues found in testing:

* Added exception handling when performing logout operations with test user accounts to prevent the tool from crashing
* Fixed error messages when verifying boot override settings
* Fixed test account creation to skip verification if the account creation fails
* Corrected tracking of supported boot parameters, which is used to dictate boot override test sequences
* Changed power/reset testing to use 'On' and 'ForceOn' as the final tests to have systems powered on when testing compeltes