### PR TITLE
Several requested updates

### DIFF
--- a/redfish_use_case_checkers/account_management.py
+++ b/redfish_use_case_checkers/account_management.py
@@ -79,6 +79,9 @@ def use_cases(sut: SystemUnderTest):
         logger.log_use_case_category_footer(CAT_NAME)
         return
 
+    # Let tasks for account operations be handled internally
+    redfish_utilities.config.__auto_task_handling__ = True
+
     # Go through the test cases
     test_username = acc_test_user_count(sut)
     user_added, test_password = acc_test_add_user(sut, test_username)

--- a/redfish_use_case_checkers/boot_override.py
+++ b/redfish_use_case_checkers/boot_override.py
@@ -526,7 +526,7 @@ def boot_test_one_time_boot_check(sut: SystemUnderTest, systems: list, check_sys
         reset_success = False
         try:
             response = redfish_utilities.system_reset(sut.session, system["Id"])
-            response = redfish_utilities.poll_task_monitor(sut.session, response)
+            response = redfish_utilities.poll_task_monitor(sut.session, response, silent=True)
             redfish_utilities.verify_response(response)
             sut.add_test_result(CAT_NAME, test_name, operation, "PASS")
             reset_success = True
@@ -544,8 +544,8 @@ def boot_test_one_time_boot_check(sut: SystemUnderTest, systems: list, check_sys
         logger.logger.info(operation)
         if reset_success:
             try:
-                # Poll the boot object for up to 300 seconds
-                for i in range(0, 30):
+                # Poll the boot object for up to 600 seconds
+                for i in range(0, 60):
                     logger.logger.debug("Monitoring check {}".format(i))
                     time.sleep(10)
                     boot_obj = redfish_utilities.get_system_boot(sut.session, system["Id"])

--- a/redfish_use_case_checkers/console_scripts.py
+++ b/redfish_use_case_checkers/console_scripts.py
@@ -109,6 +109,9 @@ def main():
     print("HTML Report: {}".format(results_file))
     print("Debug Log: {}".format(log_file))
 
+    # Exit with status 1 if there are any failures; 0 otherwise
+    sys.exit(int(sut.fail_count > 0))
+
 
 def summary_format(result, result_count):
     """

--- a/redfish_use_case_checkers/power_control.py
+++ b/redfish_use_case_checkers/power_control.py
@@ -233,7 +233,7 @@ def power_test_reset_operation(sut: SystemUnderTest, systems: list, reset_capabi
             reset_success[system["Id"]] = False
             try:
                 response = redfish_utilities.system_reset(sut.session, system["Id"], reset_type)
-                response = redfish_utilities.poll_task_monitor(sut.session, response)
+                response = redfish_utilities.poll_task_monitor(sut.session, response, silent=True)
                 redfish_utilities.verify_response(response)
                 sut.add_test_result(CAT_NAME, test_name, operation, "PASS")
                 reset_success[system["Id"]] = True

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 colorama
 redfish>=3.0.0
-redfish_utilities>=1.1.4
+redfish_utilities>=3.4.1

--- a/setup.py
+++ b/setup.py
@@ -26,5 +26,5 @@ setup(
     url="https://github.com/DMTF/Redfish-Use-Case-Checkers",
     packages=["redfish_use_case_checkers"],
     entry_points={"console_scripts": ["rf_use_case_checkers=redfish_use_case_checkers.console_scripts:main"]},
-    install_requires=["colorama", "redfish>=3.0.0", "redfish_utilities>=1.1.4"],
+    install_requires=["colorama", "redfish>=3.0.0", "redfish_utilities>=3.4.1"],
 )


### PR DESCRIPTION
Fix #76 
Fix #74 
Fix #73 

Increased the boot override test time to allow for up to 10 minutes for a system to reset and boot to the new device
Added support for leveraging new automated task monitoring in Redfish Tacklebox for account tests
Added support to use a non-zero exit code when there are failures